### PR TITLE
pin-1776: Revoke certified attribute

### DIFF
--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -57,6 +57,54 @@ paths:
             schema:
               $ref: '#/components/schemas/InternalTenantSeed'
         required: true
+  /internal/origin/{tOrigin}/externalId/{tExternalId}/attributes/origin/{aOrigin}/externalId/{aExternalId}:
+    parameters:
+      - $ref: '#/components/parameters/CorrelationIdHeader'
+      - $ref: '#/components/parameters/IpAddress'
+      - name: tOrigin
+        in: path
+        description: the origin of the tenant
+        required: true
+        schema:
+          type: string
+      - name: tExternalId
+        in: path
+        description: the externalId of the tenant
+        required: true
+        schema:
+          type: string
+      - name: aOrigin
+        in: path
+        description: the origin of the attribute
+        required: true
+        schema:
+          type: string
+      - name: aExternalId
+        in: path
+        description: the externalId of the attribute
+        required: true
+        schema:
+          type: string
+    delete:
+      tags:
+        - tenant
+      operationId: internalRevokeCertifiedAttribute
+      description: Revokes a Certified attribute to the requesting Tenant
+      responses:
+        '204':
+          description: Updated Tenant
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '404':
+          description: Tenant Attribute Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
   /m2m/tenants:
     parameters:
       - $ref: '#/components/parameters/CorrelationIdHeader'

--- a/src/main/scala/it/pagopa/interop/tenantprocess/error/ResponseHandlers.scala
+++ b/src/main/scala/it/pagopa/interop/tenantprocess/error/ResponseHandlers.scala
@@ -47,6 +47,17 @@ object ResponseHandlers extends AkkaResponses {
       case Failure(ex)                            => internalServerError(ex, logMessage)
     }
 
+  def internalRevokeCertifiedAttributeResponse[T](logMessage: String)(
+    success: T => Route
+  )(result: Try[T])(implicit contexts: Seq[(String, String)], logger: LoggerTakingImplicit[ContextFieldsToLog]): Route =
+    result match {
+      case Success(s)                                      => success(s)
+      case Failure(ex: CertifiedAttributeNotFoundInTenant) => badRequest(ex, logMessage)
+      case Failure(ex: TenantNotFound)                     => notFound(ex, logMessage)
+      case Failure(ex: RegistryAttributeNotFound)          => notFound(ex, logMessage)
+      case Failure(ex)                                     => internalServerError(ex, logMessage)
+    }
+
   def m2mUpsertTenantResponse[T](logMessage: String)(
     success: T => Route
   )(result: Try[T])(implicit contexts: Seq[(String, String)], logger: LoggerTakingImplicit[ContextFieldsToLog]): Route =

--- a/src/test/resources/authz.json
+++ b/src/test/resources/authz.json
@@ -26,6 +26,13 @@
       ]
     },
     {
+      "route": "internalRevokeCertifiedAttribute",
+      "verb": "DELETE",
+      "roles": [
+        "internal"
+      ]
+    },
+    {
       "route": "m2mUpsertTenant",
       "verb": "POST",
       "roles": [

--- a/src/test/scala/it/pagopa/interop/tenantprocess/authz/TenantApiServiceAuthzSpec.scala
+++ b/src/test/scala/it/pagopa/interop/tenantprocess/authz/TenantApiServiceAuthzSpec.scala
@@ -59,6 +59,13 @@ class TenantApiServiceAuthzSpec extends ClusteredMUnitRouteTest with SpecData {
     )
   }
 
+  test("Tenant api should accept authorized roles for internalRevokeCertifiedAttribute") {
+    validateAuthorization(
+      endpoints("internalRevokeCertifiedAttribute"),
+      { implicit c: Seq[(String, String)] => tenantService.internalRevokeCertifiedAttribute("", "", "", "") }
+    )
+  }
+
   test("Tenant api should accept authorized roles for m2mUpsertTenant") {
     validateAuthorization(
       endpoints("m2mUpsertTenant"),

--- a/src/test/scala/it/pagopa/interop/tenantprocess/utils/FakeDependencies.scala
+++ b/src/test/scala/it/pagopa/interop/tenantprocess/utils/FakeDependencies.scala
@@ -110,6 +110,8 @@ object FakeDependencies extends SpecData {
       evidence$4: JsonReader[T],
       ec: ExecutionContext
     ): Future[Seq[T]] = Future.successful(Nil)
+
+    override def close(): Unit = ()
   }
 
   val fakeTenant: Tenant = Tenant(


### PR DESCRIPTION
⚠️  The new endpoint allows to revoke also a certified attribute set by a certifier tenant.
Not sure if we can avoid this, unless we take all certifier ids and verify the given is not among them.

Thoughts?